### PR TITLE
check existence of debugInfo

### DIFF
--- a/device-info/script.js
+++ b/device-info/script.js
@@ -19,7 +19,9 @@ let canvas = document.createElement("canvas");
 let webgl = canvas.getContext("webgl") || canvas.getContext("experimental-webgl");
 let debugInfo = webgl.getExtension("RENDERER") || webgl.getExtension("webgl_debug_renderer_info");
 
-addRow("GPU", webgl.getParameter(debugInfo.UNMASKED_RENDERER_WEBGL));
+if (debugInfo) {
+    addRow("GPU", webgl.getParameter(debugInfo.UNMASKED_RENDERER_WEBGL));
+}
 
 for (const property in navigator) {
     if (


### PR DESCRIPTION
browser extensions (such as chameleon) can deploy privacy measures to make sure websites don't get sensitive client-side information. this can also cause an error making the script not continue any further.

adding a check to make sure `debugInfo` isn't set to `null` will allow the script to continue doing it's thing